### PR TITLE
Do not declare isReactComponent

### DIFF
--- a/src/ReactCursorPosition.js
+++ b/src/ReactCursorPosition.js
@@ -426,12 +426,12 @@ export default class extends React.Component {
         return  isPositionOutside;
     }
 
-    getIsReactComponent(reactElement) {
-        return typeof reactElement.type === 'function';
-    }
-
     getTouchEvent(e) {
         return e.touches[0];
+    }
+
+    getIsReactComponent(reactElement) {
+        return typeof reactElement.type === 'function';
     }
 
     shouldDecorateChild(child) {


### PR DESCRIPTION
With the React 16.5.0 release, this component's use of `isReactComponent` breaks React's `shouldConstruct` check. Here is a more detailed explanation of the problem: https://github.com/facebook/react/issues/13580

Here is a working demo of the bug: https://codesandbox.io/s/nm1nn0374