### PR TITLE
Replace unsafe lifecycle

### DIFF
--- a/src/ReactCursorPosition.js
+++ b/src/ReactCursorPosition.js
@@ -221,19 +221,17 @@ export default class extends React.Component {
         }
     }
 
-    componentWillReceiveProps({ isEnabled: willBeEnabled }) {
-        const { isEnabled } = this.props;
-        const isEnabledWillChange = isEnabled !== willBeEnabled;
-
-        if (!isEnabledWillChange) {
+    componentDidUpdate(prevProps) {
+        if (this.props.isEnabled === prevProps.isEnabled) {
             return;
         }
-
-        if (willBeEnabled) {
+        
+        if (this.props.isEnabled) {
             this.enable();
         } else {
             this.disable();
         }
+        
     }
 
     componentWillUnmount() {

--- a/test/ReactCursorPosition.spec.js
+++ b/test/ReactCursorPosition.spec.js
@@ -1110,6 +1110,7 @@ describe('ReactCursorPosition', () => {
             });
 
             it('can be disabled without remounting', () => {
+                const positionObserver = getMountedComponentTree({ isEnabled: true });
                 const instance = positionObserver.instance();
                 const spy = jest.spyOn(instance, 'disable');
 


### PR DESCRIPTION
This is to fix the following warning and to be compatible with concurrent mode: 
> Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

It shouldn't affect the functionality, but I didn't test it. I converted some other components in the similar manner and it always worked out.

