### PR TITLE
Expose full state on deactivation

### DIFF
--- a/src/ReactCursorPosition.js
+++ b/src/ReactCursorPosition.js
@@ -353,13 +353,7 @@ export default class extends React.Component {
 
     deactivate() {
         this.setState({ isActive: false }, () => {
-            const { isPositionOutside, position } = this.state;
-
-            this.props.onPositionChanged({
-                isPositionOutside,
-                position
-            });
-
+            this.props.onPositionChanged(this.state);
             this.props.onActivationChanged({ isActive: false });
         });
     }


### PR DESCRIPTION
Everything in the state should be accurate, regardless of whether it's active. It's useful to have the shape of the object sent to the `onPositionChanged` callback be the same regardless of activation.