### PR TITLE
Fixing an issue with missing propTypes

### DIFF
--- a/src/ReactCursorPosition.js
+++ b/src/ReactCursorPosition.js
@@ -472,8 +472,9 @@ export default class extends React.Component {
     }
 
     getPassThroughProps() {
-        const ownPropNames = Object.keys(this.constructor.propTypes);
-        return omit(this.props, ownPropNames);
+        const ownPropNames = Object.keys(this.constructor.propTypes || {});
+        if (ownPropNames.length)
+            return omit(this.props, ownPropNames);
     }
 
     render() {


### PR DESCRIPTION
Don't really understand the issue, but this fixes #35 by:

1. providing an empty object to Object.keys as a default
2. only emitting the event when there's actually something to send along with it

This fixes an issue I was having with another component using this one (ethanselzer/react-image-magnify)